### PR TITLE
feat: Allow for pin coordinates to be hidden via a config option

### DIFF
--- a/common/src/main/java/pepjebs/mapatlases/client/screen/DecorationBookmarkButton.java
+++ b/common/src/main/java/pepjebs/mapatlases/client/screen/DecorationBookmarkButton.java
@@ -10,6 +10,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.saveddata.maps.MapDecoration;
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import pepjebs.mapatlases.client.CompoundTooltip;
+import pepjebs.mapatlases.config.MapAtlasesClientConfig;
 import pepjebs.mapatlases.integration.moonlight.CustomDecorationButton;
 import pepjebs.mapatlases.networking.C2SRemoveMarkerPacket;
 import pepjebs.mapatlases.networking.MapAtlasesNetworking;
@@ -138,11 +139,14 @@ public abstract class DecorationBookmarkButton extends BookmarkButton {
             return Tooltip.create(Component.translatable("tooltip.map_atlases.delete_marker"));
         }
         Component mapIconComponent = getDecorationName();
-        Component coordsComponent = Component.literal("X: " + (int) getWorldX() + ", Z: " + (int) getWorldZ())
-                .withStyle(ChatFormatting.GRAY);
         var t = Tooltip.create(mapIconComponent);
-        var t2 = Tooltip.create(coordsComponent);
-        return CompoundTooltip.create(t, t2);
+        if (MapAtlasesClientConfig.drawPinMapCoords.get()) {
+            Component coordsComponent = Component.literal("X: " + (int) getWorldX() + ", Z: " + (int) getWorldZ())
+                    .withStyle(ChatFormatting.GRAY);
+            var t2 = Tooltip.create(coordsComponent);
+            return CompoundTooltip.create(t, t2);
+        }
+        return t;
     }
 
     protected boolean canFocusMarker() {

--- a/common/src/main/java/pepjebs/mapatlases/config/MapAtlasesClientConfig.java
+++ b/common/src/main/java/pepjebs/mapatlases/config/MapAtlasesClientConfig.java
@@ -120,6 +120,9 @@ public class MapAtlasesClientConfig {
         drawWorldMapCoords = builder
                 .comment("When enabled, the Atlas world map coordinates will be displayed")
                 .define("draw_coordinates", true);
+        drawPinMapCoords = builder
+                .comment("When enabled, the Atlas world map pins will have their coordinates displayed when hovered")
+                .define("draw_coordinates_pin", true);
         worldMapCoordsScale = builder
                 .comment("Sets the scale of the text rendered for Coords world-map data")
                 .define("coordinates_scale", 1, 0, 10d);
@@ -183,6 +186,7 @@ public class MapAtlasesClientConfig {
     public static final Supplier<Boolean> drawMinimapChunkCoords;
     public static final Supplier<Boolean> drawMinimapBiome;
     public static final Supplier<Boolean> drawWorldMapCoords;
+    public static final Supplier<Boolean> drawPinMapCoords;
     public static final Supplier<Boolean> drawMinimapCardinals;
     public static final Supplier<Boolean> miniMapOnlyNorth;
     public static final Supplier<Boolean> miniMapBorder;


### PR DESCRIPTION
I've been playing a modpack where we don't get to see coordinates in any easy way, this PR adds a new config that allows for the pin coordinates (currently shown on hover tooltip) to not be displayed if a new config "draw_coordinates_pin" is set to false (default true).

I believe this is still pretty inline with the mod as it aims for the vanilla-esque style while having some configs to hide coordinates in some other places, it just so happened that this became an easy way to get current coordinates via the Atlas.