### PR TITLE
Small performance improvements

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     modCompileOnly("curse.maven:jei-238222:7420587")
     modCompileOnly("curse.maven:roughly-enough-items-310111:6199140")
 
-    modCompileOnly("curse.maven:curios-309927:6274154")
+    modCompileOnly("curse.maven:curios-309927:6529130")
 
     /*
 

--- a/common/src/main/java/pepjebs/mapatlases/integration/CuriosCompat.java
+++ b/common/src/main/java/pepjebs/mapatlases/integration/CuriosCompat.java
@@ -1,16 +1,13 @@
 package pepjebs.mapatlases.integration;
 
+import net.mehvahdjukaar.candlelight.api.PlatformImpl;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
-import pepjebs.mapatlases.MapAtlasesMod;
-import top.theillusivec4.curios.api.CuriosApi;
-import top.theillusivec4.curios.api.SlotResult;
 
 public class CuriosCompat {
 
+    @PlatformImpl
     public static ItemStack getAtlasInCurio(Player player) {
-      return CuriosApi.getCuriosInventory(player)
-                .flatMap(o -> o.findFirstCurio(MapAtlasesMod.MAP_ATLAS.get()))
-              .map(SlotResult::stack).orElse(ItemStack.EMPTY);
+        throw new AssertionError();
     }
 }

--- a/common/src/main/java/pepjebs/mapatlases/mixin/MapItemMixin.java
+++ b/common/src/main/java/pepjebs/mapatlases/mixin/MapItemMixin.java
@@ -29,6 +29,7 @@ import pepjebs.mapatlases.config.MapAtlasesConfig;
 public class MapItemMixin {
 
     @Shadow @Final public static int IMAGE_HEIGHT;
+    private static LevelChunk emptyChunk;
 
     @WrapOperation(method = "update", at = @At(value = "INVOKE",
             target = "Lnet/minecraft/world/level/Level;getChunk(II)Lnet/minecraft/world/level/chunk/LevelChunk;"))
@@ -51,8 +52,11 @@ public class MapItemMixin {
             }*/
         }
         //return empty
-        return new EmptyLevelChunk(level, new ChunkPos(chunkX, chunkZ),
+        if (emptyChunk == null) {
+            emptyChunk = new EmptyLevelChunk(level, new ChunkPos(chunkX, chunkZ),
                 level.registryAccess().registryOrThrow(Registries.BIOME).getHolderOrThrow(Biomes.FOREST));
+        }
+        return emptyChunk;
     }
 
 

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     modCompileOnly("curse.maven:jei-238222:7420583")
     modCompileOnly("curse.maven:roughly-enough-items-310111:6199139")
     modCompileOnly("curse.maven:roughly-enough-items-310111:6199140")
-    modCompileOnly("curse.maven:curios-309927:6274154")
+    modCompileOnly("curse.maven:curios-309927:6529130")
     modCompileOnly("curse.maven:the-twilight-forest-227639:7797302")
 
 }

--- a/neoforge/build.gradle.kts
+++ b/neoforge/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
 
     modCompileOnly("net.mehvahdjukaar:supplementaries-neoforge:${supplementaries_version}")
     modCompileOnly("curse.maven:the-twilight-forest-227639:7797302")
-    modCompileOnly("curse.maven:curios-309927:6274154")
+    modCompileOnly("curse.maven:curios-309927:6529130")
 
     modCompileOnly("curse.maven:emi-580555:6420931")
     modCompileOnly("curse.maven:jei-238222:7420587")

--- a/neoforge/src/main/java/pepjebs/mapatlases/integration/platform/CuriosCompatImpl.java
+++ b/neoforge/src/main/java/pepjebs/mapatlases/integration/platform/CuriosCompatImpl.java
@@ -1,0 +1,39 @@
+package pepjebs.mapatlases.integration.platform;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import pepjebs.mapatlases.MapAtlasesMod;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.SlotResult;
+import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
+import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
+
+import java.util.Optional;
+
+public class CuriosCompatImpl {
+
+    public static ItemStack getAtlasInCurio(Player player) {
+        Optional<ICuriosItemHandler> curiosInventory = CuriosApi.getCuriosInventory(player);
+        if (!curiosInventory.isPresent())
+            return ItemStack.EMPTY;
+
+        Item atlas_item = MapAtlasesMod.MAP_ATLAS.get();
+        for (ICurioStacksHandler stacksHandler : curiosInventory.get().getCurios().values()) {
+            IDynamicStackHandler stacks = stacksHandler.getStacks();
+            NonNullList<Boolean> activeStates = stacksHandler.getActiveStates();
+            for (int i = 0; i < stacks.getSlots(); i++) {
+                if (activeStates.size() > i && !activeStates.get(i)) {
+                    continue;
+                }
+                ItemStack stack = stacks.getStackInSlot(i);
+                if (stack.is(atlas_item)) {
+                    return stack;
+                }
+            }
+        }
+        return ItemStack.EMPTY;
+    }
+}


### PR DESCRIPTION
I was looking at a spark performance profile, and these two functions (`CuriosCompat.getAtlasInCurio` and `mapAtlases$reduceUpdateNonGeneratedChunks`) stood out to me as being oddly slow, so I took a look at them and improved their performance somewhat.

The code in the new `getAtlasInCurio` function is mostly the same as Curio's `findFirstCurio` (https://github.com/TheIllusiveC4/Curios/blob/5204243ccceca7cb9a604fa77b21c12534206343/neoforge/src/main/java/top/theillusivec4/curios/common/capability/CurioInventoryCapability.java#L176), but with unused code/objects stripped out. 