### PR TITLE
Fix empty map duplication when cloning atlases in a cartography table

### DIFF
--- a/common/src/main/java/pepjebs/mapatlases/mixin/CartographyTableMenuMixin.java
+++ b/common/src/main/java/pepjebs/mapatlases/mixin/CartographyTableMenuMixin.java
@@ -31,9 +31,12 @@ import pepjebs.mapatlases.map_collection.MapCollection;
 import pepjebs.mapatlases.utils.AtlasCartographyTable;
 import pepjebs.mapatlases.utils.MapAtlasesAccessUtils;
 import pepjebs.mapatlases.utils.MapDataHolder;
+import pepjebs.mapatlases.utils.MapType;
 import pepjebs.mapatlases.utils.Slice;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 
@@ -95,8 +98,15 @@ public abstract class CartographyTableMenuMixin extends AbstractContainerMenu im
                 var idsToADd = bottomMaps.getIdsCopy();
                 resultMaps.addAndAssigns(result, world, idsToADd);
 
-                EmptyMaps emptyMaps = MapAtlasItem.getEmptyMaps(result);
-                emptyMaps.addAndAssigns(result, MapAtlasItem.getEmptyMaps(bottomItem).getAll());
+                // Both atlases leave the table, so split the pool rather than giving each the full sum.
+                EmptyMaps topEmpty = MapAtlasItem.getEmptyMaps(topItem);
+                EmptyMaps bottomEmpty = MapAtlasItem.getEmptyMaps(bottomItem);
+                Set<MapType> emptyTypes = new HashSet<>(topEmpty.getAll().keySet());
+                emptyTypes.addAll(bottomEmpty.getAll().keySet());
+                for (MapType type : emptyTypes) {
+                    int pooled = topEmpty.get(type) + bottomEmpty.get(type);
+                    MapAtlasItem.getEmptyMaps(result).setAndAssign(result, type, pooled / 2);
+                }
 
                 result.grow(1);
                 this.resultContainer.setItem(CartographyTableMenu.RESULT_SLOT, result);


### PR DESCRIPTION
The atlas+atlas branch of setupResultSlot pools both atlases' empty maps into the result and then calls result.grow(1). Since both atlases leave the table, that hands back twice what went in: two atlases holding 10 empty maps each produce two atlases holding 20 each.

This splits the pooled total between the two outputs instead of duplicating it. Both outputs are the same stack, so uneven splits lose the remainder rather than gaining an extra one. You could go the other way and have an atlas with 11 and an atlas with 10 both end up with 11, but that slows the duplication, doesn't really get rid of it.