### PR TITLE
Let identical atlases stack

### DIFF
--- a/common/src/main/java/pepjebs/mapatlases/map_collection/MapCollection.java
+++ b/common/src/main/java/pepjebs/mapatlases/map_collection/MapCollection.java
@@ -50,11 +50,15 @@ public class MapCollection {
     private boolean initialized = false;
 
 
+    private static final Comparator<MapId> BY_ID = Comparator.comparingInt(MapId::id);
+
     protected MapCollection(Map<MapType, List<MapId>> integers) {
         int s = 0;
         for (var e : integers.entrySet()) {
-            this.ids.computeIfAbsent(e.getKey(), k -> new ArrayList<>())
-                    .addAll(e.getValue());
+            List<MapId> list = this.ids.computeIfAbsent(e.getKey(), k -> new ArrayList<>());
+            list.addAll(e.getValue());
+            // sorted so insertion order stays out of equals(), which compares these lists
+            list.sort(BY_ID);
             s += e.getValue().size();
         }
         this.size = s;


### PR DESCRIPTION
The atlas stacksTo(16), so stacking requires every component to be equal. MapCollection.equals compares ids, an EnumMap<MapType, List<MapId>>, and List.equals is order sensitive. Two atlases covering exactly the same territory therefore refuse to stack unless their ids happen to sit in the same order, which depends on the order the maps were added, and pruning out maps to make them match will never actually match them.

Sorting each list by map id on construction keeps insertion order out of the component's identity, and makes the serialized form deterministic.

One other cause I have not touched: SELECTED_SLICES records the slice last viewed per dimension, so opening one atlas and not the other also stops them stacking. That needs a call on whether a viewing preference belongs in a stacking-relevant component.